### PR TITLE
Updating Versions following secure baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This reference implementation will go over some design decisions from the baseli
 
 Throughout the reference implementation, you will see reference to _Contoso Bicycle_. They are a fictional, small, and fast-growing startup that provides online web services to its clientele on the east coast of the United States. This narrative provides grounding for some implementation details, naming conventions, etc. You should adapt as you see fit.
 
-| 🎓 Foundational Understanding |
-|:------------------------------|
+| 🎓 Foundational Understanding                                                                                                                                                                                                                                                                                                                                                                                                           |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **If you haven't familiarized yourself with the general-purpose [AKS baseline cluster](https://github.com/mspnp/aks-secure-baseline) architecture, you should start there before continuing here.** The architecture rationalized and constructed that implementation is the direct foundation of this body of work. This reference implementation avoids rearticulating points that are already addressed in the AKS baseline cluster. |
 
 The Contoso Bicycle app team that owns the `a0042` workload app is planning to deploy an AKS cluster strategically located in the `East US 2` region as this is where most of their customer base can be found. They will operate this single AKS cluster [following Microsoft's recommended baseline architecture](https://github.com/mspnp/aks-secure-baseline).
@@ -19,7 +19,7 @@ This architectural decision will have multiple implications for the Contoso Bicy
 This project has a companion set of articles that describe challenges, design patterns, and best practices for an AKS multi cluster solution designed to be deployed in multiple region to be highly available. You can find this article on the Azure Architecture Center at [Azure Kubernetes Service (AKS) Baseline Cluster for Multi-Region deployments](https://aka.ms/architecture/aks-baseline-multi-region). If you haven't reviewed it, we suggest you read it as it will give added context to the considerations applied in this implementation. Ultimately, this is the direct implementation of that specific architectural guidance.
 
 | :construction: | The article series mentioned above has _not yet been published_. |
-|----------------|:--------------------------|
+| -------------- | :--------------------------------------------------------------- |
 
 ## Architecture
 
@@ -33,7 +33,7 @@ Finally, this implementation uses the [ASP.NET Docker samples](https://github.co
 
 #### Azure platform
 
-- Azure Kubernetes Service (AKS) v1.19
+- Azure Kubernetes Service (AKS) v1.20
 - Azure Virtual Networks (hub-spoke)
 - Azure Front Door
 - Azure Application Gateway (WAF)
@@ -43,13 +43,13 @@ Finally, this implementation uses the [ASP.NET Docker samples](https://github.co
 #### In-cluster OSS components
 
 - [Flux GitOps Operator](https://fluxcd.io)
-- [Traefik Ingress Controller](https://doc.traefik.io/traefik/v1.7/user-guide/kubernetes/)
+- [Traefik Ingress Controller](https://doc.traefik.io/traefik/v2.4/routing/providers/kubernetes-ingress/)
 - [Azure AD Pod Identity](https://github.com/Azure/aad-pod-identity)
 - [Azure KeyVault Secret Store CSI Provider](https://github.com/Azure/secrets-store-csi-driver-provider-azure)
 - [Kured](https://docs.microsoft.com/azure/aks/node-updates-kured)
 
 | :construction: | Diagram below does _NOT accurately reflect this architecture_. **Update Pending.** |
-|----------------|:--------------------------|
+| -------------- | :--------------------------------------------------------------------------------- |
 
 ![The federation diagram depicting the proposed cluster fleet topology running different instances of the same application from them.](./docs/deploy/images/aks-baseline-multi-cluster.png)
 
@@ -88,8 +88,8 @@ There is WAF protection enabled on Application Gateway and Azure Front Door. The
 
 While this reference implementation tends to avoid _preview_ features of AKS to ensure you have the best customer support experience; there are some features you may wish to evaluate in pre-production clusters that augment your posture around security, manageability, etc. Consider trying out and providing feedback on the following. As these features come out of preview, this reference implementation may be updated to incorporate them.
 
-* [Preview features coming from the AKS Secure Baseline](https://github.com/mspnp/aks-secure-baseline#preview-features)
-* _Currently the Azure Kubernetes Service (AKS) for Multi-Region Deployment does not implement any Preview feature directly_
+- [Preview features coming from the AKS Secure Baseline](https://github.com/mspnp/aks-secure-baseline#preview-features)
+- _Currently the Azure Kubernetes Service (AKS) for Multi-Region Deployment does not implement any Preview feature directly_
 
 ## Next Steps
 

--- a/cluster-manifests/base/a0042/traefik-namespaced-rbac.yaml
+++ b/cluster-manifests/base/a0042/traefik-namespaced-rbac.yaml
@@ -28,8 +28,10 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
     verbs:
       - get
       - list
@@ -43,19 +45,20 @@ rules:
   - apiGroups:
       - traefik.containo.us
     resources:
+      - middlewares
       - ingressroutes
+      - traefikservices
       - ingressroutetcps
       - ingressrouteudps
-      - middlewares
       - tlsoptions
       - tlsstores
-      - traefikservices
+      - serverstransports
     verbs:
       - get
       - list
       - watch
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-watch-workloads

--- a/cluster-manifests/base/cluster-baseline-settings/akv-secrets-store-csi.yaml
+++ b/cluster-manifests/base/cluster-baseline-settings/akv-secrets-store-csi.yaml
@@ -366,7 +366,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: secrets-store
-          image: mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.17
+          image: mcr.microsoft.com/oss/kubernetes-csi/secrets-store/driver:v0.0.20
           args:
             - "--debug=false"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -415,7 +415,7 @@ spec:
               cpu: 50m
               memory: 100Mi
         - name: liveness-probe
-          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.1.0
+          image: mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.2.0
           imagePullPolicy: Always
           args:
           - --csi-address=/csi/csi.sock
@@ -476,7 +476,7 @@ spec:
       hostNetwork: true
       containers:
         - name: provider-azure-installer
-          image: mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.10
+          image: mcr.microsoft.com/oss/azure/secrets-store/provider-azure:0.0.13
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=unix:///provider/azure.sock

--- a/cluster-manifests/base/cluster-baseline-settings/flux-system/flux.yaml
+++ b/cluster-manifests/base/cluster-baseline-settings/flux-system/flux.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: cluster-baseline-settings
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flux
   labels:
@@ -21,7 +21,7 @@ rules:
     verbs: ['*']
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flux
   labels:

--- a/cluster-manifests/base/traefik-crds.yaml
+++ b/cluster-manifests/base/traefik-crds.yaml
@@ -95,3 +95,17 @@ spec:
     plural: traefikservices
     singular: traefikservice
   scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: serverstransports.traefik.containo.us
+
+spec:
+  group: traefik.containo.us
+  version: v1alpha1
+  names:
+    kind: ServersTransport
+    plural: serverstransports
+    singular: serverstransport
+  scope: Namespaced

--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -99,7 +99,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.19.6",
+            "defaultValue": "1.20.2",
             "type": "string"
         }
     },
@@ -781,7 +781,7 @@
         },
         {
             "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2020-12-01",
+            "apiVersion": "2021-02-01",
             "name": "[variables('clusterName')]",
             "location": "[parameters('location')]",
             "dependsOn": [

--- a/docs/deploy/09-workload.md
+++ b/docs/deploy/09-workload.md
@@ -42,8 +42,8 @@ The cluster now has [Traefik configured with a TLS certificate](./08-secret-mana
    > In this moment your Ingress Controller (Traefik) is reading your ingress resource object configuration, updating its status, and creating a router to fulfill the new exposed workloads route. Please take a look at this and notice that the address is set with the Internal Load Balancer IP from the configured subnet.
 
    ```bash
-   kubectl get ingress aspnetapp-ingress -n a0042 --context $AKS_CLUSTER_NAME_BU0001A0042_03
-   kubectl get ingress aspnetapp-ingress -n a0042 --context $AKS_CLUSTER_NAME_BU0001A0042_04
+   kubectl get IngressRoute aspnetapp-ingress -n a0042 --context $AKS_CLUSTER_NAME_BU0001A0042_03
+   kubectl get IngressRoute aspnetapp-ingress -n a0042 --context $AKS_CLUSTER_NAME_BU0001A0042_04
    ```
 
    > At this point, the route to the workload is established, SSL offloading configured, and a network policy is in place to only allow Traefik to connect to your workload. Therefore, you should expect a `403` HTTP response if you attempt to connect to it directly.

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -48,7 +48,7 @@ jobs:
           az acr import --source docker.io/library/memcached:1.5.20 -n $ACR_NAME_BU0001A0042 --force
           az acr import --source docker.io/fluxcd/flux:1.19.0 -n $ACR_NAME_BU0001A0042 --force
           az acr import --source docker.io/weaveworks/kured:1.4.0 -n $ACR_NAME_BU0001A0042 --force
-          az acr import --source docker.io/library/traefik:2.2.1 -n $ACR_NAME_BU0001A0042 --force
+          az acr import --source docker.io/library/traefik:v2.4.8 -n $ACR_NAME_BU0001A0042 --force
 
         azcliversion: 2.17.1
 

--- a/workload/aspnetapp.yaml
+++ b/workload/aspnetapp.yaml
@@ -46,8 +46,8 @@ spec:
                   - traefik-ingress-ilb
               topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: aspnet-webapp-sample
-        image: mcr.microsoft.com/dotnet/samples:aspnetapp
+      - name: aspnetcore-webapp-sample
+        image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/workload/aspnetapp.yaml
+++ b/workload/aspnetapp.yaml
@@ -46,8 +46,8 @@ spec:
                   - traefik-ingress-ilb
               topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: aspnetcore-webapp-sample
-        image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+      - name: aspnet-webapp-sample
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/workload/traefik-region1.yaml
+++ b/workload/traefik-region1.yaml
@@ -143,8 +143,8 @@ spec:
         # PRODUCTION READINESS CHANGE REQUIRED
         # This image should be sourced from a non-public container registry, such as the
         # one deployed along side of this reference implementation.
-        # az acr import --source docker.io/library/traefik:2.2.1 -n <your-acr-instance-name>
-      - image: docker.io/library/traefik:2.2.1
+        # az acr import --source docker.io/library/traefik:v2.4.8 -n <your-acr-instance-name>
+      - image: docker.io/library/traefik:v2.4.8
         name: traefik-ingress-controller
         resources:
           requests:

--- a/workload/traefik-region2.yaml
+++ b/workload/traefik-region2.yaml
@@ -143,8 +143,8 @@ spec:
         # PRODUCTION READINESS CHANGE REQUIRED
         # This image should be sourced from a non-public container registry, such as the
         # one deployed along side of this reference implementation.
-        # az acr import --source docker.io/library/traefik:2.2.1 -n <your-acr-instance-name>
-      - image: docker.io/library/traefik:2.2.1
+        # az acr import --source docker.io/library/traefik:v2.4.8 -n <your-acr-instance-name>
+      - image: docker.io/library/traefik:v2.4.8
         name: traefik-ingress-controller
         resources:
           requests:


### PR DESCRIPTION
- AKS Version from 1.29 to 1.20
- AKS api version from "2020-12-01" to "2021-02-01"
- Traefik version 2.2.1 to 2.4.8
- The workload remains in netCore 3.1 because it is the best way to tell the canary story nowadays. The net6 image is still not available 
https://hub.docker.com/_/microsoft-dotnet-aspnet/ (no net6 image)
https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/aspnetapp/aspnetapp.csproj (net5 on main)
and there is not pull request in the repo.
- CSI, KeyVaultIntegration
https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure
from driver:v0.0.17 to driver:v0.0.20
from ivenessprobe:v2.1.0 to ivenessprobe:v2.2.0
from provider-azure:0.0.10 to provider-azure:0.0.13
- Small fix executing the narrative
