### PR TITLE
Moving Azure Firewall to the recent version which includes Azure Policies

### DIFF
--- a/docs/deploy/02-aad.md
+++ b/docs/deploy/02-aad.md
@@ -41,4 +41,4 @@ Following the steps below you will result in an Azure AD configuration that will
 
 ### Next step
 
-:arrow_forward: [Deploy the hub-spoke network topology](./03-networking.md)
+:arrow_forward: [Deploy share resources](./03-cluster-prerequisites.md)

--- a/docs/deploy/03-cluster-prerequisites.md
+++ b/docs/deploy/03-cluster-prerequisites.md
@@ -12,8 +12,17 @@ Following the steps below will result in the provisioning of the shared Azure re
 | Azure Private Dns Zone        | The Private Dns Zone for the Azure Container Registry. Later cluster can link their vNets to it                                                                                                                                                                                                     |
 | Azure Log Analytics Workspace | A Centralized Log Analytics workspace where all the logs are collected                                                                                                                                                                                                                              |
 | Azure Front Door              | Azure Front Door routes traffic to the fastest and available (healthy) backend. Public IP FQDN(s) emitted by the spoke network deployments are being configured in advance as AFD's backends. These regional PIP(s) are later assigned to the Azure Application Gateways Frontend Ip Configuration. |
+| Azure Firewall Policy base rules   | Firewall rules which apply to the complete organization |
 
 ## Steps
+
+1. Login into the Azure subscription that you'll be deploying the Azure resources into.
+
+   > :book: The networking team logins into the Azure subscription. At Contoso Bicycle, all of their regional hubs are in the same, centrally-managed subscription.
+
+   ```bash
+   az login -t $TENANTID_AZURERBAC
+   ```
 
 1. Create the shared services resource group for your AKS clusters.
 
@@ -35,6 +44,7 @@ Following the steps below will result in the provisioning of the shared Azure re
 > | [Log Analytics in Azure Monitor](https://docs.microsoft.com/azure/azure-monitor/logs/log-analytics-overview) |              |     ✓     |            |
 > | [Azure Container Registry](https://docs.microsoft.com/azure/container-registry/)                             |              |     ✓     |     ✓      |
 > | [Azure Front Door](https://docs.microsoft.com/azure/frontdoor/front-door-overview)                           |      ✓       |           |            |
+> | [Azure Firewall Policy](https://docs.microsoft.com/en-us/azure/firewall-manager/policy-overview)             |              |   ✓       |            |
 >
 > **Azure Monitor logs solution**
 >
@@ -65,9 +75,9 @@ Following the steps below will result in the provisioning of the shared Azure re
 > :book: The app team is about to deploy Azure Application instances in every region ahead of their corresponding cluster. It represents a new challenge for them as they need to globally manage the traffic from their clients, and route to the different regions to achieve enhanced reliability; aligning to the [Geode cloud design pattern](https://docs.microsoft.com/azure/architecture/patterns/geodes). They plan to have both regions initially active, and respond from the one which is closest to the client sending the HTTP requests. Therefore, it results in an active/active availability strategy, but they need to failover to a single region in case of a region outage. As a consequence of this last requirement, the load balancing can not be a simple round robin over the closest regions, but it also needs to be aware of the health of their backends, and derive the traffic accordingly. Two well known Azure services can perform Multi-Geo Redundancy and Closest Region Routing, they are: Azure Front Door and Azure Traffic Manager. To make final decision between these two, the Contoso organization is also seeing added benefits in Azure Front Door like better performance at the TLS negotiation, rate limiting capability and IP ACL-ing.
 
 ```bash
-az deployment group create -g rg-bu0001a0042-shared -f shared-svcs-stamp.json -p location=eastus2 fontDoorBackend="['${APPGW_FQDN_BU0001A0042_03}','${APPGW_FQDN_BU0001A0042_04}']"
+az deployment group create -g rg-bu0001a0042-shared -f shared-svcs-stamp.json -p location=eastus2
 ```
 
 ### Next step
 
-:arrow_forward: [Deploy the AKS clusters](./06-aks-cluster.md)
+:arrow_forward: [Deploy the hub-spoke network topology](./04-networking.md)

--- a/docs/deploy/03-cluster-prerequisites.md
+++ b/docs/deploy/03-cluster-prerequisites.md
@@ -1,6 +1,6 @@
 # Deploy the AKS cluster prerequisites and shared services
 
-In the prior step, you [generated the user-facing TLS certificate](./04-ca-certificates.md); now follows the next step in the [AKS baseline multi cluster reference implementation](/README.md) which is deploying the shared service instances.
+In the prior step, you [prep for Azure Active Directory integration](./02-aad.md); now follows the next step in the [AKS baseline multi cluster reference implementation](/README.md) which is deploying the shared service instances.
 
 ## Expected results
 
@@ -12,7 +12,7 @@ Following the steps below will result in the provisioning of the shared Azure re
 | Azure Private Dns Zone        | The Private Dns Zone for the Azure Container Registry. Later cluster can link their vNets to it                                                                                                                                                                                                     |
 | Azure Log Analytics Workspace | A Centralized Log Analytics workspace where all the logs are collected                                                                                                                                                                                                                              |
 | Azure Front Door              | Azure Front Door routes traffic to the fastest and available (healthy) backend. Public IP FQDN(s) emitted by the spoke network deployments are being configured in advance as AFD's backends. These regional PIP(s) are later assigned to the Azure Application Gateways Frontend Ip Configuration. |
-| Azure Firewall Policy base rules   | Firewall rules which apply to the complete organization |
+| Azure Firewall Policy base rules   | Azure Firewall rules that apply at the entire organization level. These rules are typically cluster agnostic, so they can be shared by them all. |
 
 ## Steps
 

--- a/docs/deploy/04-networking.md
+++ b/docs/deploy/04-networking.md
@@ -27,14 +27,6 @@ The following two resource groups will be created and populated with networking 
 
 ## Steps
 
-1. Login into the Azure subscription that you'll be deploying the Azure resources into.
-
-   > :book: The networking team logins into the Azure subscription that will contain the regional hub and spokes. At Contoso Bicycle, all of their regional hubs are in the same, centrally-managed subscription.
-
-   ```bash
-   az login -t $TENANTID_AZURERBAC
-   ```
-
 1. Create the networking hub-spoke resource groups.
 
    > :book: The networking team has all their regional networking hubs and spokes in the following centrally-managed Azure Resource Groups
@@ -54,10 +46,14 @@ The following two resource groups will be created and populated with networking 
    >
    > Note: The subnets for Azure Bastion and on-prem connectivity are deployed in this reference architecture, but the resources are not deployed. Since this reference implementation is expected to be deployed isolated from existing infrastructure; these IP addresses should not conflict with any existing networking you have, even if those IP addresses overlap. If you need to connect the reference implementation to existing networks, you will need to adjust the IP space as per your requirements as to not conflict in the reference ARM templates.
 
+   Company's Firewall Policy base rules where created as share resource. Each region will have his own Firewall Policy as child of the base Firewall Policies. The child Firewall Policies must be on the same region than the parent.
+
    ```bash
    # [Create the generic hubs takes about five minutes to run.]
-   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.json -n hub-regionA -p @networking/hub-region.parameters.eastus2.json
-   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.json -n hub-regionB -p @networking/hub-region.parameters.centralus.json
+   BASE_FIREWALL_POLICIES_ID=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.baseFirewallPoliciesId.value -o tsv)
+
+   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.json -n hub-regionA -p baseFirewallPoliciesId=$BASE_FIREWALL_POLICIES_ID firewallPolicyLocation=eastus2 @networking/hub-region.parameters.eastus2.json
+   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.json -n hub-regionB -p baseFirewallPoliciesId=$BASE_FIREWALL_POLICIES_ID firewallPolicyLocation=eastus2 @networking/hub-region.parameters.centralus.json
 
    # [Create the spokes takes about ten minutes to run.]
    RESOURCEID_VNET_HUB_REGIONA=$(az deployment group show -g rg-enterprise-networking-hubs -n hub-regionA --query properties.outputs.hubVnetId.value -o tsv)
@@ -65,13 +61,12 @@ The following two resource groups will be created and populated with networking 
    az deployment group create -g rg-enterprise-networking-spokes -f networking/spoke-BU0001A0042.json -n spoke-BU0001A0042-03 -p hubVnetResourceId="${RESOURCEID_VNET_HUB_REGIONA}" @networking/spoke-BU0001A0042.parameters.eastus2.json
    az deployment group create -g rg-enterprise-networking-spokes -f networking/spoke-BU0001A0042.json -n spoke-BU0001A0042-04 -p hubVnetResourceId="${RESOURCEID_VNET_HUB_REGIONB}" @networking/spoke-BU0001A0042.parameters.centralus.json
 
-    # [Enrolling the spokes into the hubs takes about three minutes to run.]
+    # [Enrolling the spokes into the hubs takes about seven minutes to run.]
    RESOURCEID_SUBNET_NODEPOOLS_BU0001A0042_03=$(az deployment group show -g  rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.nodepoolSubnetResourceIds.value -o tsv)
    RESOURCEID_SUBNET_NODEPOOLS_BU0001A0042_04=$(az deployment group show -g  rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.nodepoolSubnetResourceIds.value -o tsv)
-   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.1.json -n hub-regionA -p nodepoolSubnetResourceIds="['${RESOURCEID_SUBNET_NODEPOOLS_BU0001A0042_03}']" @networking/hub-region.parameters.eastus2.json
-   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.1.json -n hub-regionB -p nodepoolSubnetResourceIds="['${RESOURCEID_SUBNET_NODEPOOLS_BU0001A0042_04}']" @networking/hub-region.parameters.centralus.json
-   ```
-
+   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.1.json -n hub-regionA -p nodepoolSubnetResourceIds="['${RESOURCEID_SUBNET_NODEPOOLS_BU0001A0042_03}']" baseFirewallPoliciesId=$BASE_FIREWALL_POLICIES_ID firewallPolicyLocation=eastus2  @networking/hub-region.parameters.eastus2.json
+   az deployment group create -g rg-enterprise-networking-hubs -f networking/hub-region.v1.1.json -n hub-regionB -p nodepoolSubnetResourceIds="['${RESOURCEID_SUBNET_NODEPOOLS_BU0001A0042_04}']" baseFirewallPoliciesId=$BASE_FIREWALL_POLICIES_ID firewallPolicyLocation=eastus2 @networking/hub-region.parameters.centralus.json
+    ```
 ## Preparing for a Failover
 
 > :book: The networking team is now dealing with multiple clusters in different regions. Understanding how the traffic flows at layers 4 and 7 through their deployed networking topology is now more critical than ever. That's why the team is evaluating different tooling that could provide monitoring over their networks.  One of the Azure Monitor products at subscription level is Network Watcher that offers two really interesting features such as NSG Flow Logs and with that [Traffic Analytics](https://docs.microsoft.com/azure/network-watcher/traffic-analytics). The latter can bring some light over the table when it is about analyzing traffic like from where it is being originated, how it is flowing thought the different regions, or how much is benign vs malicious together with many more details at the security and performance level. [With no upfront cost and no termination fees](https://azure.microsoft.com/pricing/details/network-watcher/) the business unit (BU0001) would be charged for collection and processing logs per GB at 10-min or 60-min intervals.
@@ -82,4 +77,4 @@ The following two resource groups will be created and populated with networking 
 
 ### Next step
 
-:arrow_forward: [Generate your client-facing TLS certificate](./04-ca-certificates.md)
+:arrow_forward: [Generate your client-facing TLS certificate](./05-ca-certificates.md)

--- a/docs/deploy/04-networking.md
+++ b/docs/deploy/04-networking.md
@@ -1,6 +1,6 @@
 # Deploy the Hub-Spoke Network Topology
 
-In the prior step, you've set up an Azure AD tenant to fullfil your [cluster's control plane (Kubernetes Cluster API) authorization](./02-aad.md) needs for this reference implementation deployment. Now we will start with our first Azure resource deployment, the network resources.
+In the prior step, you've set up an Azure AD tenant to fullfil your [deployed share resources](./03-cluster-prerequisites.md) needs for this reference implementation deployment. Now we will start with the network resources.
 
 ## Subscription and resource group topology
 
@@ -46,7 +46,7 @@ The following two resource groups will be created and populated with networking 
    >
    > Note: The subnets for Azure Bastion and on-prem connectivity are deployed in this reference architecture, but the resources are not deployed. Since this reference implementation is expected to be deployed isolated from existing infrastructure; these IP addresses should not conflict with any existing networking you have, even if those IP addresses overlap. If you need to connect the reference implementation to existing networks, you will need to adjust the IP space as per your requirements as to not conflict in the reference ARM templates.
 
-   Company's Firewall Policy base rules where created as share resource. Each region will have his own Firewall Policy as child of the base Firewall Policies. The child Firewall Policies must be on the same region than the parent.
+   The Azure Firewall Base Policies for the Contoso organization were created by the networking team as another shared resource. This way, they became available for each regional cluster that requires inherit them and create children Azure Firewall policy rules on top of. An important Azure Resource Manager requirement by the time writing this is that all derivates Azure Firewall Policies must reside on the same parent's location.
 
    ```bash
    # [Create the generic hubs takes about five minutes to run.]

--- a/docs/deploy/05-ca-certificates.md
+++ b/docs/deploy/05-ca-certificates.md
@@ -66,4 +66,4 @@ Following the steps below you will result the certificates needed for Azure Appl
 
 ### Next step
 
-:arrow_forward: [Deploy the AKS cluster prerequisites](./05-cluster-prerequisites.md)
+:arrow_forward: [Deploy the AKS clusters](./06-aks-cluster.md)

--- a/docs/deploy/06-aks-cluster.md
+++ b/docs/deploy/06-aks-cluster.md
@@ -1,6 +1,6 @@
 # Deploy the AKS Clusters in two different regions
 
-Now that the [cluster prequisites and shared Azure service instances are provisioned](./05-cluster-prerequisites.md), the next step in the [AKS baseline multi cluster reference implementation](/README.md) is deploying the AKS clusters and its adjacent Azure resources.
+Now that you [generated your Client-Facing and AKS Ingress Controller TLS Certificates](./05-ca-certificates.md), the next step in the [AKS baseline multi cluster reference implementation](/README.md) is deploying the AKS clusters and its adjacent Azure resources.
 
 ## Expected results
 

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -101,7 +101,7 @@ jobs:
           cluster-manifests/base/cluster-baseline-settings/ns.yaml
           ${{ steps.aks-kustomize-region1.outputs.manifestsBundle }}
 
-    - name: Enrol Region 1 cluster on front-door
+    - name: Azure CLI - Enroll Azure Application Gateway as backend in Azure Front Door - Region 1 
       id: enrol-cluster-1
       if: success() && env.DEPLOY_REGION1 == 'true'
       uses: Azure/cli@v1.0.0
@@ -162,7 +162,7 @@ jobs:
           cluster-manifests/base/cluster-baseline-settings/ns.yaml
           ${{ steps.aks-kustomize-region2.outputs.manifestsBundle }}
 
-    - name: Enrol Region 2 cluster on front-door
+    - name: Azure CLI - Enroll Azure Application Gateway as backend in Azure Front Door - Region 2
       id: enrol-cluster-2
       if: success() && env.DEPLOY_REGION2 == 'true'
       uses: Azure/cli@v1.0.0

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -149,3 +149,20 @@ jobs:
         manifests: |
           cluster-manifests/base/cluster-baseline-settings/ns.yaml
           ${{ steps.aks-kustomize-region2.outputs.manifestsBundle }}
+
+    # Enrol all the clusters at Front-Door Backend Pool      
+    - name: Enrol all the clusters at Front-Door Backend Pool 
+      id: enrol-clusters
+      uses: Azure/cli@v1.0.0
+      with:
+        inlineScript: |
+          az extension add --upgrade -n front-door
+          APPGW_FQDN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGwFqdn.value -o tsv)
+          APPGW_FQDN_BU0001A0042_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.appGwFqdn.value -o tsv)
+          FRONT_DOOR_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorName.value -o tsv)
+          FRONT_DOOR__BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
+          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_03 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_03 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
+          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_04 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_04 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
+          az network front-door backend-pool backend remove --front-door-name $FRONT_DOOR_NAME --index 1 --pool-name $FRONT_DOOR__BACKENDPOOL_NAME --resource-group rg-bu0001a0042-shared 
+         
+        azcliversion: 2.17.1

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -101,6 +101,18 @@ jobs:
           cluster-manifests/base/cluster-baseline-settings/ns.yaml
           ${{ steps.aks-kustomize-region1.outputs.manifestsBundle }}
 
+    - name: Enrol Region 1 cluster on front-door
+      id: enrol-cluster-1
+      if: success() && env.DEPLOY_REGION1 == 'true'
+      uses: Azure/cli@v1.0.0
+      with:
+        inlineScript: |
+          az extension add --upgrade -n front-door
+          APPGW_FQDN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGwFqdn.value -o tsv)
+          FRONT_DOOR_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorName.value -o tsv)
+          FRONT_DOOR__BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
+          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_03 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_03 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
+
     # -----------------------REGION2------------------------------------------------
     # Deploy the cluster into your environment, assuming all prerequisites are up and running.
     - name: Azure CLI - Deploy AKS cluster - Region 2
@@ -150,19 +162,16 @@ jobs:
           cluster-manifests/base/cluster-baseline-settings/ns.yaml
           ${{ steps.aks-kustomize-region2.outputs.manifestsBundle }}
 
-    # Enrol all the clusters at Front-Door Backend Pool      
-    - name: Enrol all the clusters at Front-Door Backend Pool 
-      id: enrol-clusters
+    - name: Enrol Region 2 cluster on front-door
+      id: enrol-cluster-2
+      if: success() && env.DEPLOY_REGION2 == 'true'
       uses: Azure/cli@v1.0.0
       with:
         inlineScript: |
           az extension add --upgrade -n front-door
-          APPGW_FQDN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGwFqdn.value -o tsv)
           APPGW_FQDN_BU0001A0042_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.appGwFqdn.value -o tsv)
           FRONT_DOOR_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorName.value -o tsv)
           FRONT_DOOR__BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
-          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_03 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_03 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
           az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_04 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_04 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
-          az network front-door backend-pool backend remove --front-door-name $FRONT_DOOR_NAME --index 1 --pool-name $FRONT_DOOR__BACKENDPOOL_NAME --resource-group rg-bu0001a0042-shared 
          
         azcliversion: 2.17.1

--- a/github-workflow/aks-deploy.yaml
+++ b/github-workflow/aks-deploy.yaml
@@ -110,8 +110,8 @@ jobs:
           az extension add --upgrade -n front-door
           APPGW_FQDN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGwFqdn.value -o tsv)
           FRONT_DOOR_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorName.value -o tsv)
-          FRONT_DOOR__BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
-          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_03 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_03 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
+          FRONT_DOOR_BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
+          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_03 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR_BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_03 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
 
     # -----------------------REGION2------------------------------------------------
     # Deploy the cluster into your environment, assuming all prerequisites are up and running.
@@ -171,7 +171,7 @@ jobs:
           az extension add --upgrade -n front-door
           APPGW_FQDN_BU0001A0042_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.appGwFqdn.value -o tsv)
           FRONT_DOOR_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorName.value -o tsv)
-          FRONT_DOOR__BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
-          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_04 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR__BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_04 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
+          FRONT_DOOR_BACKENDPOOL_NAME=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query properties.outputs.frontDoorBackendPoolName.value -o tsv)
+          az network front-door backend-pool backend add --address $APPGW_FQDN_BU0001A0042_04 --front-door-name $FRONT_DOOR_NAME --pool-name $FRONT_DOOR_BACKENDPOOL_NAME -g rg-bu0001a0042-shared --backend-host-header $APPGW_FQDN_BU0001A0042_04 --disabled false --http-port 80 --https-port 443  --priority 1 --weight 50
          
         azcliversion: 2.17.1

--- a/networking/hub-region.v1.1.json
+++ b/networking/hub-region.v1.1.json
@@ -69,6 +69,18 @@
             "metadata": {
                 "description": "A /27 under the VNet Address Space for regional Azure Bastion"
             }
+        },
+        "baseFirewallPoliciesId":{
+            "type": "string",
+            "metadata": {
+                "description": "The org base firewall network policies id"
+            }
+        },
+        "firewallPolicyLocation":{
+            "type": "string",
+            "metadata": {
+                "description": "parent policy must be in the sane region as child policy"
+            }
         }
     },
     "variables": {
@@ -82,7 +94,8 @@
         "hubFwName": "[concat('fw-', parameters('location'))]",
         "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
         "bastionNetworkNsgName": "[concat('nsg-', parameters('location'), '-bastion')]",
-        "hubLaName": "[concat('la-hub-', parameters('location'), '-', uniqueString(resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))))]"
+        "hubLaName": "[concat('la-hub-', parameters('location'), '-', uniqueString(resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))))]",
+        "fwPoliciesName": "[concat('fw-policies-', parameters('location'))]"
     },
     "resources": [
         {
@@ -390,8 +403,398 @@
             }
         },
         {
+            "type": "Microsoft.Network/firewallPolicies",
+            "apiVersion": "2020-11-01",
+            "name": "[variables('fwPoliciesName')]",
+            "location": "[parameters('firewallPolicyLocation')]",
+            "properties": {
+                "basePolicy": {
+                    "id":  "[parameters('baseFirewallPoliciesId')]"
+                },
+                "sku": {
+                    "tier": "Standard"
+                },
+                "threatIntelMode": "Deny",
+                "threatIntelWhitelist": {
+                    "ipAddresses": []
+                },
+                "dnsSettings": {
+                    "servers": [],
+                    "enableProxy": true
+                }
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesName'), '/DefaultDnatRuleCollectionGroup')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[variables('fwPoliciesName')]"
+                    ],
+                    "properties": {
+                        "priority": 100,
+                        "ruleCollections": []
+                    }
+                },
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesName'), '/DefaultApplicationRuleCollectionGroup')]",
+                    "location":"[parameters('location')]",
+                    "dependsOn": [
+                        "[ variables('fwPoliciesName')]",
+                        "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', variables('fwPoliciesName'), 'DefaultDnatRuleCollectionGroup')]",
+                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                    ],
+                    "properties": {
+                        "priority": 300,
+                        "ruleCollections": [
+                            {
+                                "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                                "action": {
+                                    "type": "Allow"
+                                },
+                                "rules": [
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "nodes-to-api-server",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "*.hcp.eastus2.azmk8s.io"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "microsoft-container-registry",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "mcr.microsoft.com",
+                                            "*.data.mcr.microsoft.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "management-plane",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [
+                                            "AzureKubernetesService"
+                                        ],
+                                        "webCategories": [],
+                                        "targetFqdns": [],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "aad-auth",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "login.microsoftonline.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "apt-get",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "packages.microsoft.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "cluster-binaries",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "acs-mirror.azureedge.net"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "ubuntu-security-patches",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Http",
+                                                "port": 80
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "security.ubuntu.com",
+                                            "azure.archive.ubuntu.com",
+                                            "changelogs.ubuntu.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "azure-monitor-addon",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "*.ods.opinsights.azure.com",
+                                            "*.oms.opinsights.azure.com",
+                                            "eastus2.monitoring.azure.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "azure-policy-addon",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "data.policy.core.windows.net",
+                                            "store.policy.core.windows.net"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    }
+                                ],
+                                "name": "AKS-Global-Requirements",
+                                "priority": 200
+                            },
+                            {
+                                "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                                "action": {
+                                    "type": "Allow"
+                                },
+                                "rules": [
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "flux-to-github",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "github.com",
+                                            "api.github.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "ApplicationRule",
+                                        "name": "pull-flux-images",
+                                        "protocols": [
+                                            {
+                                                "protocolType": "Https",
+                                                "port": 443
+                                            }
+                                        ],
+                                        "fqdnTags": [],
+                                        "webCategories": [],
+                                        "targetFqdns": [
+                                            "*.docker.com",
+                                            "*.docker.io",
+                                            "docker.io",
+                                            "ghcr.io",
+                                            "github-production-container-registry.s3.amazonaws.com"
+                                        ],
+                                        "targetUrls": [],
+                                        "terminateTLS": false,
+                                        "sourceAddresses": [],
+                                        "destinationAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ]
+                                    }
+                                ],
+                                "name": "Flux-Requirements",
+                                "priority": 300
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesName'), '/DefaultNetworkRuleCollectionGroup')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[variables('fwPoliciesName')]",
+                        "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', variables('fwPoliciesName'), 'DefaultApplicationRuleCollectionGroup')]", 
+                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                    ],
+                    "properties": {
+                        "priority": 200,
+                        "ruleCollections": [
+                            {
+                                "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                                "action": {
+                                    "type": "Allow"
+                                },
+                                "rules": [
+                                    {
+                                        "ruleType": "NetworkRule",
+                                        "name": "ntp",
+                                        "ipProtocols": [
+                                            "UDP"
+                                        ],
+                                        "sourceAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ],
+                                        "destinationAddresses": [
+                                            "*"
+                                        ],
+                                        "destinationIpGroups": [],
+                                        "destinationFqdns": [],
+                                        "destinationPorts": [
+                                            "123"
+                                        ]
+                                    },
+                                    {
+                                        "ruleType": "NetworkRule",
+                                        "name": "pod-to-api-server",
+                                        "ipProtocols": [
+                                            "TCP"
+                                        ],
+                                        "sourceAddresses": [],
+                                        "sourceIpGroups": [
+                                            "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                                        ],
+                                        "destinationAddresses": [
+                                            "[concat('AzureCloud.', parameters('location'))]"
+                                        ],
+                                        "destinationIpGroups": [],
+                                        "destinationFqdns": [],
+                                        "destinationPorts": [
+                                            "443"
+                                        ]
+                                    }
+                                ],
+                                "name": "AKS-Global-Requirements",
+                                "priority": 200
+                            }
+                        ]
+                    }
+                }
+          ]
+        },
+        {
             "type": "Microsoft.Network/azureFirewalls",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2020-11-01",
             "name": "[variables('hubFwName')]",
             "location": "[parameters('location')]",
             "comments": "This is the regional Azure Firewall that all regional spoke networks can egress through.",
@@ -403,12 +806,10 @@
             "dependsOn": [
                 "create-fw-pips",
                 "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
-                "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
+                "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', variables('fwPoliciesName'), 'DefaultNetworkRuleCollectionGroup')]"
             ],
             "properties": {
-                "additionalProperties": {
-                    "Network.DNS.EnableProxy": "true"
-                },
+                "additionalProperties": {},
                 "sku": {
                     "name": "AZFW_VNet",
                     "tier": "Standard"
@@ -444,321 +845,11 @@
                     }
                 ],
                 "natRuleCollections": [],
-                "networkRuleCollections": [
-                    {
-                        "name": "org-wide-allowed",
-                        "properties": {
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "priority": 100,
-                            "rules": [
-                                {
-                                    "name": "DNS",
-                                    "description": "Consider restricting this to only DNS servers you expect to be used by spokes of this hub.",
-                                    "sourceAddresses": [
-                                        "*"
-                                    ],
-                                    "protocols": [
-                                        "UDP"
-                                    ],
-                                    "destinationPorts": [
-                                        "53"
-                                    ],
-                                    "destinationAddresses": [
-                                        "*"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "name": "AKS-Global-Requirements",
-                        "properties": {
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "priority": 200,
-                            "rules": [
-                                {
-                                    "name": "ntp",
-                                    "description": "Network Time Protocol (NTP) time synchronization for nodepool nodes. These use ubuntu's NTP pools.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        "UDP"
-                                    ],
-                                    "destinationPorts": [
-                                        "123"
-                                    ],
-                                    "destinationAddresses": [
-                                        "*"
-                                    ]
-                                },
-                                {
-                                    "name": "tunnelfront-pod-tcp",
-                                    "description": "Tunnelfront pod to communicate with the tunnel end on the API server. Technically only needed to our API servers instead of AzureCloud.EastUS2. Restrict this to your clusters' Cluster API Public IP; done this way for easy of demonstration. Not needed for private clusters.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        "TCP"
-                                    ],
-                                    "destinationPorts": [
-                                        "9000"
-                                    ],
-                                    "destinationAddresses": [
-                                        "[concat('AzureCloud.', parameters('location'))]"
-                                    ]
-                                },
-                                {
-                                    "name": "tunnelfront-pod-udp",
-                                    "description": "Tunnelfront pod to communicate with the tunnel end on the API server. Technically only needed to our API servers instead of AzureCloud.EastUS2. Restrict this to your clusters' Cluster API Public IP; done this way for easy of demonstration. Not needed for private clusters.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        "UDP"
-                                    ],
-                                    "destinationPorts": [
-                                        "1194"
-                                    ],
-                                    "destinationAddresses": [
-                                        "[concat('AzureCloud.', parameters('location'))]"
-                                    ]
-                                },
-                                {
-                                    "name": "pod-to-api-server",
-                                    "description": "Allows pods to communicate to the Cluster API server (e.g. Flux). Technically only needed to our API servers instead of AzureCloud.EastUS2. Restrict this to your clusters' Cluster API Public IP; done this way for ease of demonstration. Not needed for private clusters.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        "TCP"
-                                    ],
-                                    "destinationPorts": [
-                                        "443"
-                                    ],
-                                    "destinationAddresses": [
-                                        "[concat('AzureCloud.', parameters('location'))]"
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "applicationRuleCollections": [
-                    {
-                        "name": "AKS-Global-Requirements",
-                        "properties": {
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "priority": 200,
-                            "rules": [
-                                {
-                                    "name": "nodes-to-api-server",
-                                    "description": "This address is required for Node <-> API server communication.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "[concat('*.hcp.', parameters('location'), '.azmk8s.io')]"
-                                    ]
-                                },
-                                {
-                                    "name": "microsoft-container-registry",
-                                    "description": "Required to access images in Microsoft Container Registry (MCR). This registry contains first-party images (E.g., coreDNS, etc.). These images are required for the correct creation and functioning of the cluster, including scale and upgrade operations.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "mcr.microsoft.com",
-                                        "*.data.mcr.microsoft.com"
-                                    ]
-                                },
-                                {
-                                    "name": "management-plane",
-                                    "description": "This address is required for Kubernetes GET/PUT operations.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "fqdnTags": [
-                                        "AzureKubernetesService"
-                                    ]
-                                },
-                                {
-                                    "name": "aad-auth",
-                                    "description": "This address is required for Azure Active Directory authentication.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "login.microsoftonline.com"
-                                    ]
-                                },
-                                {
-                                    "name": "apt-get",
-                                    "description": "This address is the Microsoft packages repository used for cached apt-get operations. Example packages include Moby, PowerShell, and Azure CLI.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "packages.microsoft.com"
-                                    ]
-                                },
-                                {
-                                    "name": "cluster-binaries",
-                                    "description": "This address is for the repository required to download and install required binaries like kubenet and Azure CNI.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "acs-mirror.azureedge.net"
-                                    ]
-                                },
-                                {
-                                    "name": "ubuntu-security-patches",
-                                    "description": "This address lets the Linux cluster nodes download the required security patches and updates per https://docs.microsoft.com/azure/aks/limit-egress-traffic#optional-recommended-fqdn--application-rules-for-aks-clusters.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Http",
-                                            "port": 80
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "security.ubuntu.com",
-                                        "azure.archive.ubuntu.com",
-                                        "changelogs.ubuntu.com"
-                                    ]
-                                },
-                                {
-                                    "name": "azure-monitor-addon",
-                                    "description": "All required for Azure Monitor for containers per https://docs.microsoft.com/azure/aks/limit-egress-traffic#azure-monitor-for-containers - Optionally you can restrict the ods and oms wildcards to JUST your clusters' log analytics instances.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "*.ods.opinsights.azure.com",
-                                        "*.oms.opinsights.azure.com",
-                                        "[concat(parameters('location'), '.monitoring.azure.com')]"
-                                    ]
-                                },
-                                {
-                                    "name": "azure-policy-addon",
-                                    "description": "All required for Azure Policy per https://docs.microsoft.com/azure/aks/limit-egress-traffic#azure-policy",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "data.policy.core.windows.net",
-                                        "store.policy.core.windows.net"
-                                    ]
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "name": "Flux-Requirements",
-                        "properties": {
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "priority": 300,
-                            "rules": [
-                                {
-                                    "name": "flux-to-github",
-                                    "description": "This address is required for Flux <-> Github repository with the desired cluster baseline configuration.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "github.com",
-                                        "api.github.com"
-                                    ]
-                                },
-                                {
-                                    "name": "pull-flux-images",
-                                    "description": "Allows pulling images from public container registries. Not necessary when using your private ACR instance via Private Link for images you've push or imported. Included here only for those that did not fork the repo.",
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', variables('aksIpGroupName'))]"
-                                    ],
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Https",
-                                            "port": 443
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "*.docker.com",
-                                        "*.docker.io",
-                                        "docker.io",
-                                        "ghcr.io",
-                                        "github-production-container-registry.s3.amazonaws.com"
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                ]
+                "networkRuleCollections": [],
+                "applicationRuleCollections": [],
+                "firewallPolicy": {
+                    "id": "[resourceId('Microsoft.Network/firewallPolicies', variables('fwPoliciesName'))]"
+                }
             },
             "resources": [
                 {

--- a/networking/hub-region.v1.1.json
+++ b/networking/hub-region.v1.1.json
@@ -73,13 +73,13 @@
         "baseFirewallPoliciesId":{
             "type": "string",
             "metadata": {
-                "description": "The org base firewall network policies id"
+                "description": "The Azure Base Policy resource id"
             }
         },
         "firewallPolicyLocation":{
             "type": "string",
             "metadata": {
-                "description": "parent policy must be in the sane region as child policy"
+                "description": "The Azure Base Policy location that will be used for the children policies"
             }
         }
     },

--- a/networking/hub-region.v1.json
+++ b/networking/hub-region.v1.json
@@ -66,13 +66,13 @@
         "baseFirewallPoliciesId":{
             "type": "string",
             "metadata": {
-                "description": "The org base firewall network policies id"
+                "description": "The Azure Base Policy resource id"
             }
         },
         "firewallPolicyLocation":{
             "type": "string",
             "metadata": {
-                "description": "parent policy must be in the sane region as child policy"
+                "description": "The Azure Base Policy location that will be used for the children policies"
             }
         }
     },

--- a/networking/hub-region.v1.json
+++ b/networking/hub-region.v1.json
@@ -62,6 +62,18 @@
             "metadata": {
                 "description": "A /27 under the VNet Address Space for regional Azure Bastion"
             }
+        },
+        "baseFirewallPoliciesId":{
+            "type": "string",
+            "metadata": {
+                "description": "The org base firewall network policies id"
+            }
+        },
+        "firewallPolicyLocation":{
+            "type": "string",
+            "metadata": {
+                "description": "parent policy must be in the sane region as child policy"
+            }
         }
     },
     "variables": {
@@ -74,7 +86,8 @@
         "hubFwName": "[concat('fw-', parameters('location'))]",
         "hubVNetName": "[concat('vnet-', parameters('location'), '-hub')]",
         "bastionNetworkNsgName": "[concat('nsg-', parameters('location'), '-bastion')]",
-        "hubLaName": "[concat('la-hub-', parameters('location'), '-', uniqueString(resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))))]"
+        "hubLaName": "[concat('la-hub-', parameters('location'), '-', uniqueString(resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))))]",
+        "fwPoliciesName": "[concat('fw-policies-', parameters('location'))]"
     },
     "resources": [
         {
@@ -366,8 +379,73 @@
             }
         },
         {
+            "type": "Microsoft.Network/firewallPolicies",
+            "apiVersion": "2020-11-01",
+            "name": "[variables('fwPoliciesName')]",
+            "location": "[parameters('firewallPolicyLocation')]",
+            "properties": {
+                "basePolicy": {
+                    "id":  "[parameters('baseFirewallPoliciesId')]"
+                },
+                "sku": {
+                    "tier": "Standard"
+                },
+                "threatIntelMode": "Deny",
+                "threatIntelWhitelist": {
+                    "ipAddresses": []
+                },
+                "dnsSettings": {
+                    "servers": [],
+                    "enableProxy": true
+                }
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesName'), '/DefaultDnatRuleCollectionGroup')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[variables('fwPoliciesName')]"
+                    ],
+                    "properties": {
+                        "priority": 100,
+                        "ruleCollections": []
+                    }
+                },
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesName'), '/DefaultApplicationRuleCollectionGroup')]",
+                    "location":"[parameters('location')]",
+                    "dependsOn": [
+                        "[variables('fwPoliciesName')]",
+                        "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', variables('fwPoliciesName'), 'DefaultDnatRuleCollectionGroup')]"
+                    ],
+                    "properties": {
+                        "priority": 300,
+                        "ruleCollections": []
+                    }
+                },
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesName'), '/DefaultNetworkRuleCollectionGroup')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[variables('fwPoliciesName')]",
+                        "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', variables('fwPoliciesName'), 'DefaultApplicationRuleCollectionGroup')]"
+                    ],
+                    "properties": {
+                        "priority": 200,
+                        "ruleCollections": []
+                    }
+                }
+          ]
+        },
+        {
             "type": "Microsoft.Network/azureFirewalls",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2020-11-01",
             "name": "[variables('hubFwName')]",
             "location": "[parameters('location')]",
             "comments": "This is the regional Azure Firewall that all regional spoke networks can egress through.",
@@ -378,12 +456,11 @@
             ],
             "dependsOn": [
                 "create-fw-pips",
-                "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]"
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('hubVnetName'))]",
+                "[resourceId('Microsoft.Network/firewallPolicies/ruleCollectionGroups', variables('fwPoliciesName'), 'DefaultNetworkRuleCollectionGroup')]"
             ],
             "properties": {
-                "additionalProperties": {
-                    "Network.DNS.EnableProxy": "true"
-                },
+                "additionalProperties": {},
                 "sku": {
                     "name": "AZFW_VNet",
                     "tier": "Standard"
@@ -419,36 +496,11 @@
                     }
                 ],
                 "natRuleCollections": [],
-                "networkRuleCollections": [
-                    {
-                        "name": "org-wide-allowed",
-                        "properties": {
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "priority": 100,
-                            "rules": [
-                                {
-                                    "name": "DNS",
-                                    "description": "Consider restricting this to only DNS servers you expect to be used by spokes of this hub.",
-                                    "sourceAddresses": [
-                                        "*"
-                                    ],
-                                    "protocols": [
-                                        "UDP"
-                                    ],
-                                    "destinationPorts": [
-                                        "53"
-                                    ],
-                                    "destinationAddresses": [
-                                        "*"
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "applicationRuleCollections": []
+                "networkRuleCollections": [],
+                "applicationRuleCollections": [],
+                "firewallPolicy": {
+                    "id": "[resourceId('Microsoft.Network/firewallPolicies', variables('fwPoliciesName'))]"
+                }
             },
             "resources": [
                 {

--- a/shared-svcs-stamp.json
+++ b/shared-svcs-stamp.json
@@ -2,12 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "0.0.0.5",
     "parameters": {
-        "fontDoorBackend": { 
-            "type": "array",
-            "metadata": {
-                "description": "List of backend apps domain name or public ips which will be part of the backend pool"
-            }
-         },
         "location": {
             "defaultValue": "eastus2",
             "type": "string",
@@ -76,9 +70,74 @@
         "acrPrivateDnsZonesName": "privatelink.azurecr.io",
 
         "frontDoorName": "[concat('bicycle', variables('subRgUniqueString'))]",
-        "frontDoorPolicyName": "[concat('policyfd', variables('subRgUniqueString'))]"
+        "frontDoorPolicyName": "[concat('policyfd', variables('subRgUniqueString'))]",
+        "fwPoliciesBaseName": "fw-policies-base"
     },
     "resources": [
+        {
+            "type": "Microsoft.Network/firewallPolicies",
+            "apiVersion": "2020-11-01",
+            "name": "[variables('fwPoliciesBaseName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "sku": {
+                    "tier": "Standard"
+                },
+                "threatIntelMode": "Deny",
+                "threatIntelWhitelist": {
+                    "ipAddresses": []
+                },
+                "dnsSettings": {
+                    "servers": [],
+                    "enableProxy": true
+                }
+            },
+            "resources": [
+                {
+                    "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+                    "apiVersion": "2020-11-01",
+                    "name": "[concat(variables('fwPoliciesBaseName'), '/DefaultNetworkRuleCollectionGroup')]",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[variables('fwPoliciesBaseName')]"
+                    ],
+                    "properties": {
+                        "priority": 200,
+                        "ruleCollections": [
+                            {
+                                "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+                                "action": {
+                                    "type": "Allow"
+                                },
+                                "rules": [
+                                    {
+                                        "ruleType": "NetworkRule",
+                                        "name": "DNS",
+                                        "ipProtocols": [
+                                            "UDP"
+                                        ],
+                                        "sourceAddresses": [
+                                            "*"
+                                        ],
+                                        "sourceIpGroups": [],
+                                        "destinationAddresses": [
+                                            "*"
+                                        ],
+                                        "destinationIpGroups": [],
+                                        "destinationFqdns": [],
+                                        "destinationPorts": [
+                                            "53"
+                                        ]
+                                    }
+                                ],
+                                "name": "org-wide-allowed",
+                                "priority": 100
+                            }
+                        ]
+                    }
+                }
+          ]
+        },
         {
             "type": "Microsoft.Network/privateDnsZones",
             "apiVersion": "2020-06-01",
@@ -160,24 +219,6 @@
             "plan": {
                 "name": "[concat('ContainerInsights(', variables('logAnalyticsWorkspaceName'),')')]",
                 "product": "OMSGallery/ContainerInsights",
-                "promotionCode": "",
-                "publisher": "Microsoft"
-            }
-        },
-        {
-            "type": "Microsoft.OperationsManagement/solutions",
-            "apiVersion": "2015-11-01-preview",
-            "name": "[concat('AzureAppGatewayAnalytics(', variables('logAnalyticsWorkspaceName'),')')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]"
-            ],
-            "properties": {
-                "workspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName'))]"
-            },
-            "plan": {
-                "name": "[concat('AzureAppGatewayAnalytics(', variables('logAnalyticsWorkspaceName'),')')]",
-                "product": "OMSGallery/AzureAppGatewayAnalytics",
                 "promotionCode": "",
                 "publisher": "Microsoft"
             }
@@ -390,19 +431,15 @@
                     {
                         "name": "MultiClusterBackendPool",
                         "properties": {
-                            "copy": [
-                               {
-                                    "name": "backends",
-                                    "count": "[length(parameters('fontDoorBackend'))]",
-                                    "input": {
-                                        "address": "[parameters('fontDoorBackend')[copyIndex('backends')]]",
-                                        "httpPort": 80,
-                                        "httpsPort": 443,
-                                        "priority": 1,
-                                        "weight": 50,
-                                        "enabledState": "Enabled",
-                                        "backendHostHeader": "[parameters('fontDoorBackend')[copyIndex('backends')]]"
-                                    }
+                            "backends":[
+                                {
+                                "address": "bicycle.cloudapp.azure.com",
+                                "httpPort": 80,
+                                "httpsPort": 443,
+                                "priority": 1,
+                                "weight": 50,
+                                "enabledState": "Enabled",
+                                "backendHostHeader": "bicycle.cloudapp.azure.com"
                                 }
                             ],
                             "healthProbeSettings": {
@@ -509,6 +546,18 @@
         "fqdn": {
             "type": "string",
             "value": "[concat(variables('frontDoorName'), '.azurefd.net')]"
+        },
+        "frontDoorName": {
+            "type": "string",
+            "value": "[variables('frontDoorName')]"
+        },
+        "frontDoorBackendPoolName": {
+            "type": "string",
+            "value": "MultiClusterBackendPool"
+        },
+        "baseFirewallPoliciesId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Network/firewallPolicies', variables('fwPoliciesBaseName'))]"
         }
     }
 }


### PR DESCRIPTION
Firewall Policy base as share Resource
Each regional hub has its own Firewall Policy as base's child
It was moved the share resources to the beginning because the base policy needs to be created at networking creation

The Font Door needs at least one backend pool value, it is created with a dummy value and then the GitHub Action makes the change to put the real clusters and delete the dummy.

It includes the AzureAppGatewayAnalytics fix.