### PR TITLE
Use new cert flow that doesn't require sudo or public storage containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignore certificate and key files
+certs/output/*
 *.crt
 *.key
 *.pfx

--- a/certs/authenticator.sh
+++ b/certs/authenticator.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 
 STORAGE_ACCOUNT_NAME=$1
-STORAGE_CONNECTION_STRING=$2
 
-echo $CERTBOT_VALIDATION>$CERTBOT_TOKEN.txt
+echo $CERTBOT_VALIDATION>${CERTBOT_TOKEN}.txt
 
-az storage blob upload \
- --connection-string $STORAGE_CONNECTION_STRING \
- --account-name $STORAGE_ACCOUNT_NAME \
- --container-name verificationdata \
- --name ${CERTBOT_TOKEN}.txt \
- --file ./${CERTBOT_TOKEN}.txt \
- --auth-mode key
+echo "Uploading validation token to $STORAGE_ACCOUNT_NAME"
+
+az storage blob upload --account-name $STORAGE_ACCOUNT_NAME -c \$web -n "${CERTBOT_TOKEN}" -f "./${CERTBOT_TOKEN}.txt" --auth-mode key --only-show-errors
 
 rm ${CERTBOT_TOKEN}.txt

--- a/certs/letsencrypt-pip-cert-generation.sh
+++ b/certs/letsencrypt-pip-cert-generation.sh
@@ -1,36 +1,40 @@
 #!/bin/bash -x
 
-SUBDOMAIN=$1
-FQDN=$2
-IP_RESOURCE_ID=$3
-LOCATION=$4
+IP_RESOURCE_ID=$1
 
-RGNAME="rg-cert-let-encrypt-${LOCATION}"
+LOCATION=$(az network public-ip show --ids $IP_RESOURCE_ID --query location -o tsv)
+RGNAME="rg-lets-encrypt-cert-validator-${LOCATION}"
 
-az group create --name ${RGNAME} --location ${LOCATION}
+FQDN=$(az network public-ip show --ids $IP_RESOURCE_ID --query dnsSettings.fqdn -o tsv)
+SUBDOMAIN=$(az network public-ip show --ids $IP_RESOURCE_ID --query dnsSettings.domainNameLabel -o tsv)
 
-az deployment group create -g "${RGNAME}" --template-uri "https://raw.githubusercontent.com/mspnp/letsencrypt-pip-cert-generation/0b981f882b473f0e6a01d5fe1153d75fa80ed56a/resources-stamp.json" --name ca-cert-generation -p location=$LOCATION subdomainName=$SUBDOMAIN ipResourceId=$IP_RESOURCE_ID
+echo "Location: $LOCATION"
+echo "DNS Prefix: $SUBDOMAIN"
+echo "FQDN: $FQDN"
+echo "Existing IP Resource ID: $IP_RESOURCE_ID"
 
-STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n ca-cert-generation --query properties.outputs.storageAccountName.value -o tsv)
-STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -g $RGNAME -n $STORAGE_ACCOUNT_NAME --query "connectionString")
+echo "Creating temporary Resource Group $RGNAME"
+az group create -n $RGNAME -l $LOCATION
 
-echo Storage Account: $STORAGE_ACCOUNT_NAME
-az storage container create --account-name $STORAGE_ACCOUNT_NAME --name verificationdata --auth-mode login --public-access container
+echo "Deploying Azure resources used in validation; this may take 20 minutes."
+# TODO: Once merged upstream, point to a stable version
+az deployment group create -g $RGNAME -u "https://raw.githubusercontent.com/mspnp/letsencrypt-pip-cert-generation/private-container/resources-stamp.json" -n $SUBDOMAIN -p location=${LOCATION} subdomainName=${SUBDOMAIN} ipResourceId=${IP_RESOURCE_ID}
 
-echo "${SUBDOMAIN}" > test.txt
-az storage blob upload \
- --connection-string $STORAGE_CONNECTION_STRING \
- --account-name $STORAGE_ACCOUNT_NAME \
- --container-name verificationdata \
- --name test.txt \
- --file ./test.txt \
- --auth-mode key
+STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n $SUBDOMAIN --query properties.outputs.storageAccountName.value -o tsv)
 
+echo "Enabling web hosting on $STORAGE_ACCOUNT_NAME"
+az storage blob service-properties update --account-name $STORAGE_ACCOUNT_NAME --static-website true --auth-mode login
+
+echo "Uploading placeholder to storage"
+echo pong>ping.txt
+az storage blob upload --account-name $STORAGE_ACCOUNT_NAME -c \$web -n ping -f ./ping.txt --auth-mode key
+
+echo "Starting cert generation and validation"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-certbot certonly --manual --manual-auth-hook "${DIR}/authenticator.sh $STORAGE_ACCOUNT_NAME $STORAGE_CONNECTION_STRING" -d $FQDN --config-dir ./certs/output/etc/letsencrypt --work-dir ./certs/output/var/lib/letsencrypt --logs-dir ./certs/output/var/log/letsencrypt
+certbot certonly --manual --manual-auth-hook "${DIR}/authenticator.sh ${STORAGE_ACCOUNT_NAME}" -d $FQDN --config-dir ./certs/output/etc/letsencrypt --work-dir ./certs/output/var/lib/letsencrypt --logs-dir ./certs/output/var/log/letsencrypt
 
-openssl pkcs12 -export -out $SUBDOMAIN.pfx -inkey ./certs/output/etc/letsencrypt/live/$FQDN/privkey.pem -in ./certs/output/etc/letsencrypt/live/$FQDN/cert.pem -certfile ./certs/output/etc/letsencrypt/live/$FQDN/chain.pem -passout pass:
+openssl pkcs12 -export -out ${SUBDOMAIN}.pfx -inkey ./certs/output/etc/letsencrypt/live/${FQDN}/privkey.pem -in ./certs/output/etc/letsencrypt/live/${FQDN}/cert.pem -certfile ./certs/output/etc/letsencrypt/live/${FQDN}/chain.pem -passout pass:
 
 echo "Deleting resources"
-az group delete -n $RGNAME --yes
-rm -rf ./certs/output ./test.txt
+az group delete -n $RGNAME --yes --no-wait
+rm -rf ./certs/output ./ping.txt

--- a/certs/letsencrypt-pip-cert-generation.sh
+++ b/certs/letsencrypt-pip-cert-generation.sh
@@ -17,8 +17,7 @@ echo "Creating temporary Resource Group $RGNAME"
 az group create -n $RGNAME -l $LOCATION
 
 echo "Deploying Azure resources used in validation; this may take 20 minutes."
-# TODO: Once merged upstream, point to a stable version
-az deployment group create -g $RGNAME -u "https://raw.githubusercontent.com/mspnp/letsencrypt-pip-cert-generation/private-container/resources-stamp.json" -n $SUBDOMAIN -p location=${LOCATION} subdomainName=${SUBDOMAIN} ipResourceId=${IP_RESOURCE_ID}
+az deployment group create -g $RGNAME -u "https://github.com/mspnp/letsencrypt-pip-cert-generation/blob/a4f89d43004d4250af02c2bc2194d62467690422/resources-stamp.json" -n $SUBDOMAIN -p location=${LOCATION} subdomainName=${SUBDOMAIN} ipResourceId=${IP_RESOURCE_ID}
 
 STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n $SUBDOMAIN --query properties.outputs.storageAccountName.value -o tsv)
 

--- a/docs/deploy/05-ca-certificates.md
+++ b/docs/deploy/05-ca-certificates.md
@@ -17,23 +17,12 @@ Following the steps below you will result the certificates needed for Azure Appl
 
    > :book: The Contoso Bicycle organization has an important policy that every internet-facing endpoint exposed over the Https protocol must use a trusted CA certificate, and it is not allowed to share a common wildcard certificate between them. Therefore, the organization needs to procure individual trusted CA certificates for all their Public IPs' FQDNs in the different regions. The Azure Application Gateway instances are going to be serving these certificates in front of every region they get deployed to.
 
-   The following command sets up some temporary infrastructure and executes a script that will generate public CA certificates. Part of that transient process creates a storage account with anonymous, public blob container access to act as a web host for some generated static files required for domain ownership validation. **This step will terminally fail if your subscription has the _Storage account public access should be disallowed_ Azure Policy set to _deny_**, as that blocks the creation of Azure Blob storage containers with anonymous access. You'll need an exception to this policy for the transient resources groups prefixed with `rg-cert-let-encrypt-`. An alternative method will be developed to eliminate this requirement, but it is not yet available.
-
    ```bash
-   # get the Public IP FQDNs, their subdomins, and resource IDs
-   APPGW_FQDN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGwFqdn.value -o tsv)
-   APPGW_FQDN_BU0001A0042_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.appGwFqdn.value -o tsv)
-   APPGW_SUBDOMAIN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.subdomainName.value -o tsv)
-   APPGW_SUBDOMAIN_BU0001A0042_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.subdomainName.value -o tsv)
-   APPGW_IP_RESOURCE_ID_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGatewayPublicIp.value -o tsv)
-   APPGW_IP_RESOURCE_ID_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.appGatewayPublicIp.value -o tsv)
-
-   # call the Let's Encrypt certificate generation script for both PIP FQDNs
-   # [Generating the following certificates takes about ten minutes to run.]
-   sudo chmod +x ./certs/letsencrypt-pip-cert-generation.sh
-   sudo chmod +x ./certs/authenticator.sh
-   ./certs/letsencrypt-pip-cert-generation.sh $APPGW_SUBDOMAIN_BU0001A0042_03 $APPGW_FQDN_BU0001A0042_03 $APPGW_IP_RESOURCE_ID_03 eastus2
-   ./certs/letsencrypt-pip-cert-generation.sh $APPGW_SUBDOMAIN_BU0001A0042_04 $APPGW_FQDN_BU0001A0042_04 $APPGW_IP_RESOURCE_ID_04 centralus
+   # call the Let's Encrypt certificate generation script for both PIPs' FQDNs
+   # [Generating the certificates takes about twenty minutes to run.]
+   chmod +x ./certs/letsencrypt-pip-cert-generation.sh ./certs/authenticator.sh
+   ./certs/letsencrypt-pip-cert-generation.sh $(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.appGatewayPublicIp.value -o tsv)
+   ./certs/letsencrypt-pip-cert-generation.sh $(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.appGatewayPublicIp.value -o tsv)
    ```
 
    :bulb: EV certificates are mostly recommended for user-facing endpoints, which is not the case in this multi region reference implementation. The Azure Application Gateways instances are going to be just the regional backend servers for a globally distributed load balancer. For more information on how these certificates are being generated, please refer to [Certificate Generation for an Azure Public IP with your DNS Prefix](https://github.com/mspnp/letsencrypt-pip-cert-generation).
@@ -43,6 +32,10 @@ Following the steps below you will result the certificates needed for Azure Appl
    :bulb: No matter if you used a certificate from your organization or you generated one from above, you'll need the certificate (as `.pfx`) to be Base64 encoded for proper storage in Key Vault later.
 
    ```bash
+   # get the Public IP subdomins
+   APPGW_SUBDOMAIN_BU0001A0042_03=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-03 --query properties.outputs.subdomainName.value -o tsv)
+   APPGW_SUBDOMAIN_BU0001A0042_04=$(az deployment group show -g rg-enterprise-networking-spokes -n spoke-BU0001A0042-04 --query properties.outputs.subdomainName.value -o tsv)
+
    APP_GATEWAY_LISTENER_REGION1_CERTIFICATE_BASE64=$(cat ${APPGW_SUBDOMAIN_BU0001A0042_03}.pfx | base64 | tr -d '\n')
    APP_GATEWAY_LISTENER_REGION2_CERTIFICATE_BASE64=$(cat ${APPGW_SUBDOMAIN_BU0001A0042_04}.pfx | base64 | tr -d '\n')
    ```

--- a/shared-svcs-stamp.json
+++ b/shared-svcs-stamp.json
@@ -322,7 +322,7 @@
         {
             "name": "PodFailedScheduledQuery",
             "type": "microsoft.insights/scheduledqueryrules",
-            "location": "global",
+            "location": "[parameters('location')]",
             "apiVersion": "2021-02-01-preview",
             "tags": {},
             "properties": {


### PR DESCRIPTION
* Also fixes the `global` issue for `scheduledQueryRules` (temporary until further research is provided)
* Reduces another `sudo` usage
* Synced deployment scripts to be closer with the new deployment scripts upstream.
* Pointed updated ARM template found upstream from the result of  mspnp/letsencrypt-pip-cert-generation#2