### PR TITLE
Update PDB to GA api version (GA as of 1.21)

### DIFF
--- a/workload/aspnetapp-canary.yaml
+++ b/workload/aspnetapp-canary.yaml
@@ -68,7 +68,7 @@ spec:
       nodeSelector:
        agentpool: npuser01
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: aspnetapp-pdb

--- a/workload/aspnetapp.yaml
+++ b/workload/aspnetapp.yaml
@@ -68,7 +68,7 @@ spec:
       nodeSelector:
        agentpool: npuser01
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: aspnetapp-pdb


### PR DESCRIPTION
As of 1.21, PDBs are now GA.  Spec didn't change, so updating the API version to remove the warning that you'll see if you deploy with the beta API version.