### PR TITLE
Fix traefik configuration error, causing forwarded headers to be ignored from upstream IPs

### DIFF
--- a/workload/traefik-region1.yaml
+++ b/workload/traefik-region1.yaml
@@ -49,7 +49,7 @@ data:
         address = ":9000"
       [entryPoints.websecure]
         address = ":8443"
-        [entryPoints.web.forwardedHeaders]
+        [entryPoints.websecure.forwardedHeaders]
           trustedIPs = ["10.243.4.16/28"]
         [entryPoints.websecure.http.tls]
           options = "default"

--- a/workload/traefik-region2.yaml
+++ b/workload/traefik-region2.yaml
@@ -49,7 +49,7 @@ data:
         address = ":9000"
       [entryPoints.websecure]
         address = ":8443"
-        [entryPoints.web.forwardedHeaders]
+        [entryPoints.websecure.forwardedHeaders]
           trustedIPs = ["10.244.4.16/28"]
         [entryPoints.websecure.http.tls]
           options = "default"


### PR DESCRIPTION
This pull request updates the Traefik configuration, to use the correct entrypoint when whitelisting upstream trusted IPs for forwarded headers. 
Fixes #39 