### PR TITLE
Updates for `az ad` breaking changes.

### DIFF
--- a/docs/deploy/01-prerequisites.md
+++ b/docs/deploy/01-prerequisites.md
@@ -4,6 +4,10 @@ This is the starting point for the instructions on deploying the [AKS baseline m
 
 ## Steps
 
+1. Latest [Azure CLI installed](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) (must be at least 2.37), or you can perform this from Azure Cloud Shell by clicking below.
+
+   [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
+
 1. Login into your Azure subscription, and save your Azure subscription's tenant id.
 
    > :warning: The user or service principal initiating the deployment process _must_ have the following minimal set of Azure Role-Based Access Control (RBAC) roles:
@@ -46,10 +50,6 @@ This is the starting point for the instructions on deploying the [AKS baseline m
    ```
 
    :warning: If the tenant highlighted in red is not correct, start over by login into the proper Azure Directory Tenant for Kubernetes Cluster API authorization.
-
-1. Latest [Azure CLI installed](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) or you can perform this from Azure Cloud Shell by clicking below.
-
-   [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
 
 1. Install [GitHub CLI](https://github.com/cli/cli/#installation)
 

--- a/docs/deploy/02-aad.md
+++ b/docs/deploy/02-aad.md
@@ -24,20 +24,20 @@ Following the steps below you will result in an Azure AD configuration that will
    # create a single admin for both clusters
    TENANTDOMAIN_K8SRBAC=$(az ad signed-in-user show --query 'userPrincipalName' -o tsv | cut -d '@' -f 2 | sed 's/\"//')
    AADOBJECTNAME_USER_CLUSTERADMIN=bu0001a0042-admin
-   AADOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${AADOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${AADOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-login --password ChangeMebu0001a0042AdminChangeMe --query objectId -o tsv)
+   AADOBJECTID_USER_CLUSTERADMIN=$(az ad user create --display-name=${AADOBJECTNAME_USER_CLUSTERADMIN} --user-principal-name ${AADOBJECTNAME_USER_CLUSTERADMIN}@${TENANTDOMAIN_K8SRBAC} --force-change-password-next-sign-in --password ChangeMebu0001a0042AdminChangeMe --query id -o tsv)
 
    # create the admin groups
    AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004203=cluster-admins-bu0001a0042-03
    AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004204=cluster-admins-bu0001a0042-04
-   AADOBJECTID_GROUP_CLUSTERADMIN_BU0001A004203=$(az ad group create --display-name $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004203 --mail-nickname $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004203 --description "Principals in this group are cluster admins in the bu0001a004203 cluster." --query objectId -o tsv)
-   AADOBJECTID_GROUP_CLUSTERADMIN_BU0001A004204=$(az ad group create --display-name $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004204 --mail-nickname $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004204 --description "Principals in this group are cluster admins in the bu0001a004204 cluster." --query objectId -o tsv)
+   AADOBJECTID_GROUP_CLUSTERADMIN_BU0001A004203=$(az ad group create --display-name $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004203 --mail-nickname $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004203 --description "Principals in this group are cluster admins in the bu0001a004203 cluster." --query id -o tsv)
+   AADOBJECTID_GROUP_CLUSTERADMIN_BU0001A004204=$(az ad group create --display-name $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004204 --mail-nickname $AADOBJECTNAME_GROUP_CLUSTERADMIN_BU0001A004204 --description "Principals in this group are cluster admins in the bu0001a004204 cluster." --query id -o tsv)
 
    # assign the admin as new member in both groups
    az ad group member add -g $AADOBJECTID_GROUP_CLUSTERADMIN_BU0001A004203 --member-id $AADOBJECTID_USER_CLUSTERADMIN
    az ad group member add -g $AADOBJECTID_GROUP_CLUSTERADMIN_BU0001A004204 --member-id $AADOBJECTID_USER_CLUSTERADMIN
    ```
 
-   :bulb: For a better security segregation your organization might require to create multiple admins. This reference implementation creates a single one for the sake of simplicity. The group object ID will be used later while creating the different clusters. This way, once the clusters gets deployed the new group will get the proper Cluster Role bindings in Kubernetes. For more information, please refer to our [AKS Baseline](https://github.com/mspnp/aks-secure-baseline).
+   :bulb: For a better security segregation your organization might require to create multiple admins. This reference implementation creates a single one for the sake of simplicity. The group object ID will be used later while creating the different clusters. This way, once the clusters gets deployed the new group will get the proper Cluster Role bindings in Kubernetes. For more information, please refer to our [AKS Baseline](https://github.com/mspnp/aks-baseline).
 
 ### Next step
 

--- a/docs/deploy/07-workload-prerequisites.md
+++ b/docs/deploy/07-workload-prerequisites.md
@@ -15,8 +15,8 @@ Now that [the AKS clusters](./06-aks-cluster.md) have been deployed and enrolled
    ```bash
    KEYVAULT_NAME_BU0001A0042_03=$(az deployment group show -g rg-bu0001a0042-03 -n cluster-stamp --query properties.outputs.keyVaultName.value -o tsv)
    KEYVAULT_NAME_BU0001A0042_04=$(az deployment group show -g rg-bu0001a0042-04 -n cluster-stamp --query properties.outputs.keyVaultName.value -o tsv)
-   az keyvault set-policy --certificate-permissions import list get --object-id $(az ad signed-in-user show --query 'objectId' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_03
-   az keyvault set-policy --certificate-permissions import list get --object-id $(az ad signed-in-user show --query 'objectId' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_04
+   az keyvault set-policy --certificate-permissions import list get --object-id $(az ad signed-in-user show --query 'id' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_03
+   az keyvault set-policy --certificate-permissions import list get --object-id $(az ad signed-in-user show --query 'id' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_04
    ```
 
 1. Import the AKS Ingress Controller's Wildcard Certificate for `*.aks-ingress.contoso.com`.
@@ -35,8 +35,8 @@ Now that [the AKS clusters](./06-aks-cluster.md) have been deployed and enrolled
    > The Azure Key Vault Policy for your user was a temporary policy to allow you to upload the certificate for this walkthrough. In actual deployments, you would manage these access policies via your ARM templates using [Azure RBAC for Key Vault data plane](https://docs.microsoft.com/azure/key-vault/general/secure-your-key-vault#data-plane-and-access-policies).
 
    ```bash
-   az keyvault delete-policy --object-id $(az ad signed-in-user show --query 'objectId' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_03
-   az keyvault delete-policy --object-id $(az ad signed-in-user show --query 'objectId' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_04
+   az keyvault delete-policy --object-id $(az ad signed-in-user show --query 'id' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_03
+   az keyvault delete-policy --object-id $(az ad signed-in-user show --query 'id' -o tsv) -n $KEYVAULT_NAME_BU0001A0042_04
    ```
 
 ## Check Azure Policies are in place


### PR DESCRIPTION
`az ad` and `az role` are now Microsoft Graph-based (instead of Azure AD Graph-based), which means some of the results are different than they were before. This brings this implementation in line with the latest.

Changes: https://docs.microsoft.com/cli/azure/microsoft-graph-migration

Also moved a dependency to be listed in the right spot; before it is actually used.