### PR TITLE
Update to latest supported 1.22 (pre-upgrade to 1.24)

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -93,7 +93,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.22.2",
+            "defaultValue": "1.22.11",
             "type": "string"
         }
     },


### PR DESCRIPTION
Prior version no longer available.  Updating to the latest of the 1.22 line before going to 1.24+