### PR TITLE
PodFailedScheduledQuery

### DIFF
--- a/shared-svcs-stamp.json
+++ b/shared-svcs-stamp.json
@@ -314,6 +314,9 @@
             "name": "PodFailedScheduledQuery",
             "type": "microsoft.insights/scheduledqueryrules",
             "location": "[parameters('location')]",
+            "dependsOn": [
+                 "[resourceId('Microsoft.OperationsManagement/solutions',concat('ContainerInsights(', variables('logAnalyticsWorkspaceName'),')'))]"
+            ],
             "apiVersion": "2021-08-01",
             "tags": {},
             "properties": {


### PR DESCRIPTION
Fixes: #49

There is a race condition where PodFailedScheduledQuery (a scheduled query rule) might fail to deploy if Container Insights hasn't finished installing. 

5 out of 5 deploy success after the change adding the depends on

