### PR TITLE
Updates

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -93,7 +93,7 @@
             }
         },
         "kubernetesVersion": {
-            "defaultValue": "1.24.6",
+            "defaultValue": "1.27.3",
             "type": "string"
         },
         "gitOpsBootstrappingRepoHttpsUrl": {

--- a/docs/deploy/01-prerequisites.md
+++ b/docs/deploy/01-prerequisites.md
@@ -24,20 +24,6 @@ This is the starting point for the instructions on deploying the [AKS baseline m
 
    [![Launch Azure Cloud Shell](https://learn.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
 
-1. While the following feature(s) are still in _preview_, please enable them in your target subscription.
-
-   1. [Register the Workload Identity preview feature = `EnableWorkloadIdentityPreview`](https://learn.microsoft.com/azure/aks/workload-identity-deploy-cluster#register-the-enableworkloadidentitypreview-feature-flag)
-
-   ```bash
-   az feature register --namespace "Microsoft.ContainerService" -n "EnableWorkloadIdentityPreview"
-
-   # Keep running until all say "Registered." (This may take up to 20 minutes.)
-   az feature list -o table --query "[?name=='Microsoft.ContainerService/EnableWorkloadIdentityPreview'].{Name:name,State:properties.state}"
-
-   # When all say "Registered" then re-register the AKS resource provider
-   az provider register --namespace Microsoft.ContainerService
-   ```
-
 1. Install [GitHub CLI](https://github.com/cli/cli/#installation)
 
 1. Login GitHub Cli

--- a/docs/deploy/06-aks-cluster.md
+++ b/docs/deploy/06-aks-cluster.md
@@ -55,19 +55,22 @@ Following the steps below will result in the provisioning of the AKS multi clust
 
         ```bash
         # Get the managed identity to assign necessary deployment permissions
-        export GITHUB_FEDERATED_IDENTITY_CLIENTID=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query 'properties.outputs.githubFederatedIdentityClientId.value' -o tsv)
-        echo GITHUB_FEDERATED_IDENTITY_CLIENTID: $GITHUB_FEDERATED_IDENTITY_CLIENTID
+        export GITHUB_FEDERATED_IDENTITY_PRINCIPALID=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query 'properties.outputs.githubFederatedIdentityPrincipalId.value' -o tsv)
+        echo GITHUB_FEDERATED_IDENTITY_PRINCIPALID: $GITHUB_FEDERATED_IDENTITY_PRINCIPALID
 
         # Assign built-in Contributor RBAC role for creating resource groups and performing deployments at subscription level
-        az role assignment create --assignee $GITHUB_FEDERATED_IDENTITY_CLIENTID --role 'Contributor'
+        az role assignment create --assignee $GITHUB_FEDERATED_IDENTITY_PRINCIPALID --role 'Contributor'
 
         # Assign built-in User Access Administrator RBAC role since granting RBAC access to other resources during the cluster creation will be required at subscription level (e.g. AKS-managed Internal Load Balancer, ACR, Managed Identities, etc.)
-        az role assignment create --assignee $GITHUB_FEDERATED_IDENTITY_CLIENTID --role 'User Access Administrator'
+        az role assignment create --assignee $GITHUB_FEDERATED_IDENTITY_PRINCIPALID --role 'User Access Administrator'
         ```
 
     1. Create federated identity secrets in your GitHub repository.
 
         ```bash
+        export GITHUB_FEDERATED_IDENTITY_CLIENTID=$(az deployment group show -g rg-bu0001a0042-shared -n shared-svcs-stamp --query 'properties.outputs.githubFederatedIdentityClientId.value' -o tsv)
+        echo GITHUB_FEDERATED_IDENTITY_CLIENTID: $GITHUB_FEDERATED_IDENTITY_CLIENTID
+
         export SUBSCRIPTION_ID=$(az account show --query id -o tsv)
         echo SUBSCRIPTION_ID: $SUBSCRIPTION_ID
         

--- a/shared-svcs-stamp.json
+++ b/shared-svcs-stamp.json
@@ -593,6 +593,10 @@
         "githubFederatedIdentityClientId": {
             "type": "string",
             "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'ghActionFederatedIdentity')).clientId]"
+        },
+         "githubFederatedIdentityPrincipalId": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', 'ghActionFederatedIdentity')).principalId]"
         }
     }
 }


### PR DESCRIPTION
1- AKS Version
2- Workload Identity is not on preview any more
3- A fix, we need the ObjectId (Principal) to assign the roles, not the client id. The fix is ghAction Identity configuration.