### PR TITLE
patch (security): [deployment] add secure decorator to x509 private keys

### DIFF
--- a/cluster-stamp.json
+++ b/cluster-stamp.json
@@ -50,9 +50,9 @@
             }
         },
         "appGatewayListenerCertificate": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
-                "description": "The certificate data for app gateway TLS termination. It is base64"
+                "description": "The PFX certificate for app gateway TLS termination. It is base64"
             }
         },
         "aksIngressControllerCertificate": {


### PR DESCRIPTION
- [bug fix: change to securestring type the x509 private key for appgw](https://github.com/mspnp/aks-baseline-multi-region/commit/7af806a4f7fef043b8301232dcf4bd85ed5d5115)