### PR TITLE
Skip Log Analytics query validation during Bicep deployment

### DIFF
--- a/shared-svcs-stamp.bicep
+++ b/shared-svcs-stamp.bicep
@@ -230,6 +230,7 @@ resource PodFailedScheduledQuery 'Microsoft.Insights/scheduledQueryRules@2023-03
     ]
     windowSize: 'PT5M'
     overrideQueryTimeRange: 'P2D'
+    skipQueryValidation: true
     criteria: {
       allOf: [
         {


### PR DESCRIPTION
This PR works around a potential deployment race condition.

We deploy a scheduled query rule to detect failed pods. However, the query references a Kusto table that only exists after Container Insights is deployed and running, which takes an unpredictable amount of time.

To work around deployment failures, the Azure Monitor PG advised skipping query validation.