### PR TITLE
patch (deployment): [iac] remove all warnings 

### DIFF
--- a/docs/deploy/01-prerequisites.md
+++ b/docs/deploy/01-prerequisites.md
@@ -26,6 +26,8 @@ This is the starting point for the instructions on deploying the [AKS baseline m
 
    [![Launch Azure Cloud Shell](https://learn.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
 
+1. Latest [Azure Bicep CLI](https://learn.microsoft.com/cli/azure/bicep?view=azure-cli-latest#az-bicep-install) installed (version 0.29.47 or higher for better experience). Please ensure you select the right platform for your environment setup.
+
 1. Latest [GitHub CLI](https://github.com/cli/cli/#installation). *OpenSSL is already installed in Azure Cloud Shell.*
 
 1. Install [Certbot](https://certbot.eff.org/instructions)

--- a/networking/hub-region.v1.1.bicep
+++ b/networking/hub-region.v1.1.bicep
@@ -518,6 +518,7 @@ resource fwPolicy 'Microsoft.Network/firewallPolicies@2024-01-01' = {
               fqdnTags: []
               webCategories: []
               targetFqdns: [
+                #disable-next-line no-hardcoded-env-urls
                 'login.microsoftonline.com'
               ]
               targetUrls: []
@@ -632,7 +633,9 @@ resource fwPolicy 'Microsoft.Network/firewallPolicies@2024-01-01' = {
               fqdnTags: []
               webCategories: []
               targetFqdns: [
+                #disable-next-line no-hardcoded-env-urls
                 'data.policy.core.windows.net'
+                #disable-next-line no-hardcoded-env-urls
                 'store.policy.core.windows.net'
               ]
               targetUrls: []

--- a/networking/hub-region.v1.1.bicep
+++ b/networking/hub-region.v1.1.bicep
@@ -518,7 +518,7 @@ resource fwPolicy 'Microsoft.Network/firewallPolicies@2024-01-01' = {
               fqdnTags: []
               webCategories: []
               targetFqdns: [
-                #disable-next-line no-hardcoded-env-urls
+                #disable-next-line no-hardcoded-env-urls // Disabling this rule because we explicitly want to allow Microsoft Entra ID authentication for the application, and this scenario is specific to the public Azure cloud.
                 'login.microsoftonline.com'
               ]
               targetUrls: []
@@ -633,7 +633,7 @@ resource fwPolicy 'Microsoft.Network/firewallPolicies@2024-01-01' = {
               fqdnTags: []
               webCategories: []
               targetFqdns: [
-                #disable-next-line no-hardcoded-env-urls
+                #disable-next-line no-hardcoded-env-urls // Disabling this rule because these specific FQDNs should be allowed (https://learn.microsoft.com/azure/aks/outbound-rules-control-egress#required-fqdn--application-rules-3).
                 'data.policy.core.windows.net'
                 #disable-next-line no-hardcoded-env-urls
                 'store.policy.core.windows.net'

--- a/shared-svcs-stamp.bicep
+++ b/shared-svcs-stamp.bicep
@@ -7,7 +7,7 @@ targetScope = 'resourceGroup'
 param location string = resourceGroup().location
 
 @description('For Azure resources that support native geo-redunancy, provide the location the redundant service will have its secondary. Should be different than the location parameter and ideally should be a paired region - https://learn.microsoft.com/azure/reliability/cross-region-replication-azure#azure-paired-regions. This region does not need to support availability zones.')
-@minLength(4)
+@minLength(5)
 param geoRedundancyLocation string = 'centralus'
 
 @description('Your GitHub account where you\'ve forked the repo.')
@@ -99,7 +99,6 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09
   resource allPrometheus 'savedSearches@2020-08-01' = {
     name: 'AllPrometheus'
     properties: {
-      eTag: '*'
       category: 'Prometheus'
       displayName: 'All collected Prometheus information'
       query: 'InsightsMetrics | where Namespace == "prometheus"'
@@ -110,7 +109,6 @@ resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09
   resource forbiddenReponsesOnIngress 'savedSearches@2020-08-01' = {
     name: 'ForbiddenReponsesOnIngress'
     properties: {
-      eTag: '*'
       category: 'Prometheus'
       displayName: 'Increase number of forbidden response on the Ingress Controller'
       query: 'let value = toscalar(InsightsMetrics | where Namespace == "prometheus" and Name == "traefik_entrypoint_requests_total" | where parse_json(Tags).code == 403 | summarize Value = avg(Val) by bin(TimeGenerated, 5m) | summarize min = min(Value)); InsightsMetrics | where Namespace == "prometheus" and Name == "traefik_entrypoint_requests_total" | where parse_json(Tags).code == 403 | summarize AggregatedValue = avg(Val)-value by bin(TimeGenerated, 5m) | order by TimeGenerated | render barchart'


### PR DESCRIPTION
This PR enhance the ux when deploying the RI 
- remove all warnings from bicep files (shared & hub)
- add pre-req to avoid schema types not found

shared
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/f3f8f822-c6fe-49b7-848e-ebc9e01260dc">

hubv1
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/67abf5e4-14cc-424f-bcad-5e082acee6b8">

spoke
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/75259513-bac5-40c5-99ae-e3ce23a90369">

hubv1.1
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/50183519-1da8-47cd-9ed4-69dfc25b7ca4">

cluster
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/d3a049b8-06fc-45da-b82e-6691a559f009">


